### PR TITLE
"cd_search_results" template added. MTC-28577

### DIFF
--- a/themes/jungfrau/theme.yaml
+++ b/themes/jungfrau/theme.yaml
@@ -173,6 +173,8 @@ elements:
             label: ポップアップ画像
           search_results:
             label: 検索結果
+          cd_search_results:
+            label: コンテン検索結果
     importer: template_set
   default_category_sets:
     importer: default_category_sets

--- a/themes/jungfrau/theme.yaml
+++ b/themes/jungfrau/theme.yaml
@@ -174,7 +174,7 @@ elements:
           search_results:
             label: 検索結果
           cd_search_results:
-            label: コンテン検索結果
+            label: コンテンツの検索結果
     importer: template_set
   default_category_sets:
     importer: default_category_sets


### PR DESCRIPTION
"cd_search_results" system template cannot be created by the user.
It should be defined in theme.yaml.